### PR TITLE
DaemonSet update for Gateway and Activator

### DIFF
--- a/manifest/2-serving-core.yaml
+++ b/manifest/2-serving-core.yaml
@@ -370,7 +370,7 @@ roleRef:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: activator
   namespace: knative-serving
@@ -379,7 +379,7 @@ metadata:
     app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/name: knative-serving
 spec:
-  replicas: 2
+  # replicas: 2
   selector:
     matchLabels:
       app: activator
@@ -394,16 +394,16 @@ spec:
         app.kubernetes.io/version: "1.12.1"
     spec:
       serviceAccountName: activator
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                - node1
-                - node3
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #       - matchExpressions:
+      #         - key: kubernetes.io/hostname
+      #           operator: In
+      #           values:
+      #           - node1
+      #           - node3
       containers:
         - name: activator
           # This is the Go import path for the binary that is containerized
@@ -6326,30 +6326,30 @@ data:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: activator
-  namespace: knative-serving
-  labels:
-    app.kubernetes.io/component: activator
-    app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.12.1"
-spec:
-  minReplicas: 1
-  maxReplicas: 20
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: activator
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          # Percentage of the requested CPU
-          averageUtilization: 100
+# apiVersion: autoscaling/v2
+# kind: HorizontalPodAutoscaler
+# metadata:
+#   name: activator
+#   namespace: knative-serving
+#   labels:
+#     app.kubernetes.io/component: activator
+#     app.kubernetes.io/name: knative-serving
+#     app.kubernetes.io/version: "1.12.1"
+# spec:
+#   minReplicas: 1
+#   maxReplicas: 20
+#   scaleTargetRef:
+#     apiVersion: apps/v1
+#     kind: Deployment
+#     name: activator
+#   metrics:
+#     - type: Resource
+#       resource:
+#         name: cpu
+#         target:
+#           type: Utilization
+#           # Percentage of the requested CPU
+#           averageUtilization: 100
 ---
 # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
 # Given the subsetting and that the activators are partially stateful systems, we want

--- a/manifest/3-kourier.yaml
+++ b/manifest/3-kourier.yaml
@@ -448,7 +448,7 @@ spec:
 # limitations under the License.
 
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: 3scale-kourier-gateway
   namespace: kourier-system
@@ -458,11 +458,11 @@ metadata:
     app.kubernetes.io/version: "1.12.1"
     app.kubernetes.io/name: knative-serving
 spec:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 100%
+  # strategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 0
+  #     maxSurge: 100%
   selector:
     matchLabels:
       app: 3scale-kourier-gateway
@@ -606,31 +606,31 @@ spec:
     app: 3scale-kourier-gateway
   type: ClusterIP
 ---
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: 3scale-kourier-gateway
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.12.1"
-    app.kubernetes.io/name: knative-serving
-spec:
-  minReplicas: 1
-  maxReplicas: 10
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: 3scale-kourier-gateway
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          # Percentage of the requested CPU
-          averageUtilization: 100
+# apiVersion: autoscaling/v2
+# kind: HorizontalPodAutoscaler
+# metadata:
+#   name: 3scale-kourier-gateway
+#   namespace: kourier-system
+#   labels:
+#     networking.knative.dev/ingress-provider: kourier
+#     app.kubernetes.io/component: net-kourier
+#     app.kubernetes.io/version: "1.12.1"
+#     app.kubernetes.io/name: knative-serving
+# spec:
+#   minReplicas: 1
+#   maxReplicas: 10
+#   scaleTargetRef:
+#     apiVersion: apps/v1
+#     kind: Deployment
+#     name: 3scale-kourier-gateway
+#   metrics:
+#     - type: Resource
+#       resource:
+#         name: cpu
+#         target:
+#           type: Utilization
+#           # Percentage of the requested CPU
+#           averageUtilization: 100
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
## Thay đổi trong Pull request

### Sửa DaemonSet cho Gateway và Activator

#### Gateway

- Đã cập nhật cấu hình DaemonSet của Gateway.

#### Activator

- Sửa cấu hình DaemonSet của Activator.

### Comment các mục sau:

- **activator replicas**: Do DaemonSet luôn đảm bảo số pod ở mỗi node là 1 nên loại bỏ trường replicas
  
- **activator affinity**: Do DaemonSet luôn đảm bảo mỗi node đều có pod nên loại bỏ trường affinity
  
- **HorizontalPodAutoscaler của activator và gateway**: Do DaemonSet luôn đảm bảo số pod ở mỗi node là 1 nên loại bỏ phần HorizontalPodAutoscaler
  
- **Strategy của Gateway**: DaemonSet không nhận trường Strategy nên comment nó đi
