### PR TITLE
hotfix hack/replace-image.sh

### DIFF
--- a/hack/replace-image.sh
+++ b/hack/replace-image.sh
@@ -7,7 +7,7 @@ kubectl -n knative-serving patch deploy net-kourier-controller --patch \
     '{"spec":{"template":{"spec":{"containers":[{"name":"controller","image":"docker.io/bonavadeur/ikukantai-kourier:'${TAG}'"}]}}}}'
 kubectl -n knative-serving patch deploy controller --patch \
     '{"spec":{"template":{"spec":{"containers":[{"name":"controller","image":"docker.io/bonavadeur/ikukantai-controller:'${TAG}'"}]}}}}'
-kubectl -n knative-serving patch deploy activator --patch \
+kubectl -n knative-serving patch daemonset activator --patch \
     '{"spec":{"template":{"spec":{"containers":[{"name":"activator","image":"docker.io/bonavadeur/ikukantai-activator:'${TAG}'"}]}}}}'
 kubectl -n knative-serving patch deploy autoscaler --patch \
     '{"spec":{"template":{"spec":{"containers":[{"name":"autoscaler","image":"docker.io/bonavadeur/ikukantai-autoscaler:'${TAG}'"}]}}}}'
@@ -20,4 +20,4 @@ kubectl -n knative-serving patch configmap config-deployment --patch \
 
 # replace image of miporin
 kubectl -n knative-serving patch deploy miporin --patch \
-    '{"spec":{"template":{"spec":{"containers":[{"name":"autoscaler","image":"docker.io/bonavadeur/miporin:'${TAG}'"}]}}}}'
+    '{"spec":{"template":{"spec":{"containers":[{"name":"miporin","image":"docker.io/bonavadeur/miporin:'${TAG}'"}]}}}}'


### PR DESCRIPTION
# Fix Ikukantai version 2.0 16/10/2026
## Fix some syntax error in version 2.0
Let take a look at `hack/replace-image.sh`
### In line 10 and 11
Replace 

```bash
kubectl -n knative-serving patch deploy activator --patch \
    '{"spec":{"template":{"spec":{"containers":[{"name":"activator","image":"docker.io/bonavadeur/ikukantai-activator:'${TAG}'"}]}}}}'
```

By

```bash
kubectl -n knative-serving patch daemonset activator --patch \
    '{"spec":{"template":{"spec":{"containers":[{"name":"activator","image":"docker.io/bonavadeur/ikukantai-activator:'${TAG}'"}]}}}}'
```

### In line 22 and 23
Replace

```bash
kubectl -n knative-serving patch deploy miporin --patch \
    '{"spec":{"template":{"spec":{"containers":[{"name":"autoscaler","image":"docker.io/bonavadeur/miporin:'${TAG}'"}]}}}}'
```
By
```bash
kubectl -n knative-serving patch deploy miporin --patch \
    '{"spec":{"template":{"spec":{"containers":[{"name":"miporin","image":"docker.io/bonavadeur/miporin:'${TAG}'"}]}}}}'
```